### PR TITLE
Renovate: update awscli at most once each weekend

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "packageNames": ["awscli"],
+      "extends": ["schedule:weekends"]
+    }
   ]
 }


### PR DESCRIPTION
`aswcli` updates almost every weekday, which is pretty noisy and easy to lose track of. Let’s make it so it updates once a week, on weekends.